### PR TITLE
registerSetting() -> registerSettings()

### DIFF
--- a/api/Global.d.ts
+++ b/api/Global.d.ts
@@ -3,12 +3,12 @@ import Joplin from './Joplin';
 /**
  * @ignore
  */
+/**
+ * @ignore
+ */
 export default class Global {
     private joplin_;
-    private requireWhiteList_;
     constructor(implementation: any, plugin: Plugin, store: any);
     get joplin(): Joplin;
-    private requireWhiteList;
-    require(filePath: string): any;
     get process(): any;
 }

--- a/api/Joplin.d.ts
+++ b/api/Joplin.d.ts
@@ -49,4 +49,17 @@ export default class Joplin {
     get views(): JoplinViews;
     get interop(): JoplinInterop;
     get settings(): JoplinSettings;
+    /**
+     * It is not possible to bundle native packages with a plugin, because they
+     * need to work cross-platforms. Instead access to certain useful native
+     * packages is provided using this function.
+     *
+     * Currently these packages are available:
+     *
+     * - [sqlite3](https://www.npmjs.com/package/sqlite3)
+     * - [fs-extra](https://www.npmjs.com/package/fs-extra)
+     *
+     * [View the demo plugin](https://github.com/laurent22/joplin/tree/dev/packages/app-cli/tests/support/plugins/nativeModule)
+     */
+    require(_path: string): any;
 }

--- a/api/JoplinPlugins.d.ts
+++ b/api/JoplinPlugins.d.ts
@@ -23,4 +23,21 @@ export default class JoplinPlugins {
      * @deprecated Use joplin.contentScripts.register()
      */
     registerContentScript(type: ContentScriptType, id: string, scriptPath: string): Promise<void>;
+    /**
+     * Gets the plugin own data directory path. Use this to store any
+     * plugin-related data. Unlike [[installationDir]], any data stored here
+     * will be persisted.
+     */
+    dataDir(): Promise<string>;
+    /**
+     * Gets the plugin installation directory. This can be used to access any
+     * asset that was packaged with the plugin. This directory should be
+     * considered read-only because any data you store here might be deleted or
+     * re-created at any time. To store new persistent data, use [[dataDir]].
+     */
+    installationDir(): Promise<string>;
+    /**
+     * @deprecated Use joplin.require()
+     */
+    require(_path: string): any;
 }

--- a/api/JoplinSettings.d.ts
+++ b/api/JoplinSettings.d.ts
@@ -22,10 +22,17 @@ export default class JoplinSettings {
     private get keyPrefix();
     private namespacedKey;
     /**
-     * Registers a new setting. Note that registering a setting item is dynamic and will be gone next time Joplin starts.
+     * Registers new settings.
+     * Note that registering a setting item is dynamic and will be gone next time Joplin starts.
      * What it means is that you need to register the setting every time the plugin starts (for example in the onStart event).
      * The setting value however will be preserved from one launch to the next so there is no risk that it will be lost even if for some
      * reason the plugin fails to start at some point.
+     */
+    registerSettings(settings: Record<string, SettingItem>): Promise<void>;
+    /**
+     * @deprecated Use joplin.settings.registerSettings()
+     *
+     * Registers a new setting.
      */
     registerSetting(key: string, settingItem: SettingItem): Promise<void>;
     /**

--- a/api/JoplinWorkspace.d.ts
+++ b/api/JoplinWorkspace.d.ts
@@ -35,7 +35,7 @@ export default class JoplinWorkspace {
      */
     onNoteContentChange(callback: Function): Promise<void>;
     /**
-     * Called when the content of a note changes.
+     * Called when the content of the current note changes.
      */
     onNoteChange(handler: ItemChangeHandler): Promise<Disposable>;
     /**

--- a/api/types.ts
+++ b/api/types.ts
@@ -330,16 +330,57 @@ export enum SettingItemType {
 export interface SettingItem {
 	value: any;
 	type: SettingItemType;
-	public: boolean;
-	label: string;
 
+	label: string;
 	description?: string;
-	isEnum?: boolean;
+
+	/**
+	 * A public setting will appear in the Configuration screen and will be
+	 * modifiable by the user. A private setting however will not appear there,
+	 * and can only be changed programmatically. You may use this to store some
+	 * values that you do not want to directly expose.
+	 */
+	public: boolean;
+
+	/**
+	 * You would usually set this to a section you would have created
+	 * specifically for the plugin.
+	 */
 	section?: string;
-	options?: any;
+
+	/**
+	 * To create a setting with multiple options, set this property to `true`.
+	 * That setting will render as a dropdown list in the configuration screen.
+	 */
+	isEnum?: boolean;
+
+	/**
+	 * This property is required when `isEnum` is `true`. In which case, it
+	 * should contain a map of value => label.
+	 */
+	options?: Record<any, any>;
+
+	/**
+	 * Reserved property. Not used at the moment.
+	 */
 	appTypes?: string[];
+
+	/**
+	 * Set this to `true` to store secure data, such as passwords. Any such
+	 * setting will be stored in the system keychain if one is available.
+	 */
 	secure?: boolean;
+
+	/**
+	 * An advanced setting will be moved under the "Advanced" button in the
+	 * config screen.
+	 */
 	advanced?: boolean;
+
+	/**
+	 * Set the min, max and step values if you want to restrict an int setting
+	 * to a particular range.
+	 */
 	minimum?: number;
 	maximum?: number;
 	step?: number;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -66,7 +66,8 @@ export class Settings {
             description: 'JiraIssue allows you to track your jira issues from Joplin and to update their status when it is modified on Jira. In order to track an issue use the context menu in your notes and add a new template. For more info: https://github.com/marc0l92/joplin-plugin-jira-issue#readme'
         });
 
-        await joplin.settings.registerSetting('jiraHost', {
+        await joplin.settings.registerSettings({
+            ['jiraHost']: {
             value: this._jiraHost,
             type: SettingItemType.String,
             section: 'jiraIssue.settings',
@@ -74,8 +75,8 @@ export class Settings {
             advanced: false,
             label: 'Jira server: host',
             description: 'Hostname of your company jira server.'
-        });
-        await joplin.settings.registerSetting('username', {
+        },
+        ['username']: {
             value: this._username,
             type: SettingItemType.String,
             section: 'jiraIssue.settings',
@@ -83,8 +84,8 @@ export class Settings {
             advanced: false,
             label: 'Jira server: account username',
             description: 'Username of your jira account used to access the API using basic authentication.'
-        });
-        await joplin.settings.registerSetting('password', {
+        },
+        ['password']: {
             value: this._password,
             type: SettingItemType.String,
             section: 'jiraIssue.settings',
@@ -93,10 +94,8 @@ export class Settings {
             secure: true,
             label: 'Jira server: account password',
             description: 'Password of your jira account used to access the API using basic authentication.'
-        });
-
-        // Render settings
-        await joplin.settings.registerSetting('renderKey', {
+        },
+        ['renderKey']: {
             value: this._renderKey,
             type: SettingItemType.Bool,
             section: 'jiraIssue.settings',
@@ -104,8 +103,8 @@ export class Settings {
             advanced: false,
             label: 'Render: code',
             description: 'Render the field $.key'
-        });
-        await joplin.settings.registerSetting('renderPriority', {
+        },
+        ['renderPriority']: {
             value: this._renderPriority,
             type: SettingItemType.Bool,
             section: 'jiraIssue.settings',
@@ -113,8 +112,8 @@ export class Settings {
             advanced: false,
             label: 'Render: priority',
             description: 'Render the field $.fields.priority.name'
-        });
-        await joplin.settings.registerSetting('renderDueDate', {
+        },
+        ['renderDueDate']: {
             value: this._renderDueDate,
             type: SettingItemType.Bool,
             section: 'jiraIssue.settings',
@@ -122,8 +121,8 @@ export class Settings {
             advanced: false,
             label: 'Render: due date',
             description: 'Render the field $.fields.duedate'
-        });
-        await joplin.settings.registerSetting('renderStatus', {
+        },
+        ['renderStatus']: {
             value: this._renderStatus,
             type: SettingItemType.Bool,
             section: 'jiraIssue.settings',
@@ -131,8 +130,8 @@ export class Settings {
             advanced: false,
             label: 'Render: status',
             description: 'Render the field $.fields.status.name'
-        });
-        await joplin.settings.registerSetting('renderAssignee', {
+        },
+        ['renderAssignee']: {
             value: this._renderAssignee,
             type: SettingItemType.Bool,
             section: 'jiraIssue.settings',
@@ -140,8 +139,8 @@ export class Settings {
             advanced: false,
             label: 'Render: assignee',
             description: 'Render the field $.fields.assignee.displayName'
-        });
-        await joplin.settings.registerSetting('renderCreator', {
+        },
+        ['renderCreator']: {
             value: this._renderCreator,
             type: SettingItemType.Bool,
             section: 'jiraIssue.settings',
@@ -149,8 +148,8 @@ export class Settings {
             advanced: false,
             label: 'Render: creator',
             description: 'Render the field $.fields.creator.displayName'
-        });
-        await joplin.settings.registerSetting('renderReporter', {
+        },
+        ['renderReporter']: {
             value: this._renderReporter,
             type: SettingItemType.Bool,
             section: 'jiraIssue.settings',
@@ -158,8 +157,8 @@ export class Settings {
             advanced: false,
             label: 'Render: reporter',
             description: 'Render the field $.fields.reporter.displayName'
-        });
-        await joplin.settings.registerSetting('renderProgress', {
+        },
+        ['renderProgress']: {
             value: this._renderProgress,
             type: SettingItemType.Bool,
             section: 'jiraIssue.settings',
@@ -167,8 +166,8 @@ export class Settings {
             advanced: false,
             label: 'Render: progress',
             description: 'Render the field $.fields.aggregateprogress.percent'
-        });
-        await joplin.settings.registerSetting('renderType', {
+        },
+        ['renderType']: {
             value: this._renderType,
             type: SettingItemType.Bool,
             section: 'jiraIssue.settings',
@@ -176,8 +175,8 @@ export class Settings {
             advanced: false,
             label: 'Render: type',
             description: 'Render the field $.fields.issuetype.name'
-        });
-        await joplin.settings.registerSetting('renderTypeIcon', {
+        },
+        ['renderTypeIcon']: {
             value: this._renderTypeIcon,
             type: SettingItemType.Bool,
             section: 'jiraIssue.settings',
@@ -185,8 +184,8 @@ export class Settings {
             advanced: false,
             label: 'Render: type icon',
             description: 'Render the field $.fields.issuetype.iconUrl'
-        });
-        await joplin.settings.registerSetting('renderSummary', {
+        },
+        ['renderSummary']: {
             value: this._renderSummary,
             type: SettingItemType.Bool,
             section: 'jiraIssue.settings',
@@ -194,9 +193,9 @@ export class Settings {
             advanced: false,
             label: 'Render: summary',
             description: 'Render the field $.fields.summary'
-        });
+        },
 
-        await joplin.settings.registerSetting('issueRenderingMode', {
+        ['issueRenderingMode']: {
             value: this._issueRenderingMode,
             type: SettingItemType.String,
             isEnum: true,
@@ -206,8 +205,8 @@ export class Settings {
             advanced: false,
             label: 'JiraIssues rendering mode',
             description: 'Rendering method of JiraIssues'
-        });
-        await joplin.settings.registerSetting('searchRenderingMode', {
+        },
+        ['searchRenderingMode']: {
             value: this._searchRenderingMode,
             type: SettingItemType.String,
             isEnum: true,
@@ -217,10 +216,10 @@ export class Settings {
             advanced: false,
             label: 'JiraSearch rendering mode',
             description: 'Rendering method of JiraSearch'
-        });
+        },
 
         // Templates
-        await joplin.settings.registerSetting('searchTemplateQuery', {
+        ['searchTemplateQuery']: {
             value: this._searchTemplateQuery,
             type: SettingItemType.String,
             section: 'jiraIssue.settings',
@@ -228,6 +227,7 @@ export class Settings {
             advanced: false,
             label: 'JiraSearch template default query',
             description: 'Default query to use when a new JiraSearch is created using the template option'
+        }
         });
 
         // initially read settings


### PR DESCRIPTION
registerSetting() is now deprecated, so for me this plugin would not show up in the settings (or work for that matter) without changing this. I also got an error message in the console about registerSetting() being deprecated.

The commit includes an update of the API files taken from the templates repository.