### PR TITLE
Cleaning plugin name from its own submenu

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ joplin.plugins.register({
         // Register command
         await joplin.commands.register({
             name: CommandsId.IssueInline,
-            label: 'JiraIssue: Insert inline issue template',
+            label: 'Insert inline issue template',
             iconName: 'fa fa-pencil',
             execute: async () => {
                 await joplin.commands.execute('insertText', Templates.IssueInline)
@@ -57,7 +57,7 @@ joplin.plugins.register({
         })
         await joplin.commands.register({
             name: CommandsId.IssueFence,
-            label: 'JiraIssue: Insert issues block template',
+            label: 'Insert issues block template',
             iconName: 'fa fa-pencil',
             execute: async () => {
                 await joplin.commands.execute('insertText', Templates.IssueFence)
@@ -65,7 +65,7 @@ joplin.plugins.register({
         })
         await joplin.commands.register({
             name: CommandsId.SearchInline,
-            label: 'JiraIssue: Insert inline search template',
+            label: 'Insert inline search template',
             iconName: 'fa fa-pencil',
             execute: async () => {
                 await joplin.commands.execute('insertText', Templates.SearchInline)
@@ -73,7 +73,7 @@ joplin.plugins.register({
         })
         await joplin.commands.register({
             name: CommandsId.SearchFence,
-            label: 'JiraIssue: Insert searches block template',
+            label: 'Insert searches block template',
             iconName: 'fa fa-pencil',
             execute: async () => {
                 await joplin.commands.execute('insertText', Templates.SearchFence)
@@ -81,7 +81,7 @@ joplin.plugins.register({
         })
         await joplin.commands.register({
             name: CommandsId.ClearCache,
-            label: 'JiraIssue: Clear cache',
+            label: 'Clear cache',
             iconName: 'fa fa-sync',
             execute: async () => {
                 cache.clear()


### PR DESCRIPTION
I believe it is obvious that options in menu "Jiraissue" relate to the options of the plugin, hence no need for the text "Jiraissue:" in front of every option in the menu. I believe for accessibility sake making the lines a bit less verbose is beneficial for easier comprehension.

![image](https://user-images.githubusercontent.com/44114323/144087055-8d3685f9-4bcf-417e-a8fc-4cf56a131a6b.png)
