### PR TITLE
allow a bearer token to be used and update version

### DIFF
--- a/src/jiraClient.ts
+++ b/src/jiraClient.ts
@@ -32,6 +32,9 @@ export class JiraClient {
         if (this._settings.get('username')) {
             requestHeaders.set('Authorization', 'Basic ' + btoa(this._settings.get('username') + ':' + this._settings.get('password')))
         }
+        else {
+            requestHeaders.set('Authorization', 'Bearer ' + this._settings.get('password'))
+        }
         const options: RequestInit = {
             method: 'GET',
             headers: requestHeaders,
@@ -73,6 +76,9 @@ export class JiraClient {
         const requestHeaders: HeadersInit = new Headers
         if (this._settings.get('username')) {
             requestHeaders.set('Authorization', 'Basic ' + btoa(this._settings.get('username') + ':' + this._settings.get('password')))
+        }
+        else {
+            requestHeaders.set('Authorization', 'Bearer ' + this._settings.get('password'))
         }
         const queryParameters = new URLSearchParams({
             jql: query,
@@ -127,6 +133,9 @@ export class JiraClient {
         const requestHeaders: HeadersInit = new Headers
         if (this._settings.get('username')) {
             requestHeaders.set('Authorization', 'Basic ' + btoa(this._settings.get('username') + ':' + this._settings.get('password')))
+        }
+        else {
+            requestHeaders.set('Authorization', 'Bearer ' + this._settings.get('password'))
         }
         const options: RequestInit = {
             method: 'GET',

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 1,
     "id": "com.github.marc0l92.joplin-plugin-jira-issue",
     "app_min_version": "1.7",
-    "version": "2.2.2",
+    "version": "2.2.3",
     "name": "Jira Issue",
     "description": "Retrieve Atlassian Jira issues information using their api in order to track the status of them from your Joplin notes.",
     "author": "marc0l92",


### PR DESCRIPTION
i am not a nodejs developer so not sure what else would need to be done. I thought about putting a checkbox to select which type of authentication to use however you had an if to check for the username, so I used that. If you don't input a username then it assumes you are using a bearer token.

works against my company jira which disabled basic auth.